### PR TITLE
Blender 2.93 and general cleanup

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,9 +19,6 @@
 #
 # ----------------------------------------------------------
 
-# Addon info
-# ----------------------------------------------------------
-
 bl_info = {
     "name": "Shape Key Transfer",
     "description": "Copies shape keys from one mesh to another.",
@@ -34,66 +31,42 @@ bl_info = {
     "category": 'Mesh'}
 
 
-# register
-# ----------------------------------------------------------
-
 import bpy
-from bpy.props import (PointerProperty, CollectionProperty, StringProperty)
+from bpy.props import PointerProperty, CollectionProperty
 from . uisettings import *
 from . shapekeytransfer import *
 
-    
-# Custom scene properties
 
-bpy.types.Scene.customshapekeylist_index = IntProperty()
-bpy.types.Scene.srcMeshShapeKey = StringProperty()
-bpy.types.Scene.destMeshShapeKey = StringProperty()
-def load_custom_properties():
-    bpy.types.Scene.shapekeytransferSettings = PointerProperty(type=UISettings)
-    bpy.types.Scene.customshapekeylist = CollectionProperty(type=ShapeKeyItem)
-    bpy.types.Scene.shapekeytransferOperatorSettings = PointerProperty(type=TransferShapeKeysOperatorUI)
-
-#bpy.app.handlers.load_post.append(load_custom_properties)
+classes = (
+    SKT_PG_settings,
+    SKT_PG_shapeKeyListItem,
+    SKT_OT_copyKeyNames,
+    SKT_OT_insertKeyNames,
+    SKT_OT_transferShapeKeys,
+    SKT_OT_transferExcludedShapeKeys,
+    SKT_OT_removeShapeKeys,
+    SKT_OT_actions,
+    SKT_OT_clearList,
+    SKT_OT_removeDuplicates,
+    SKT_UL_items,
+    SKT_PT_view3D
+)
 
 def register():
-    bpy.utils.register_class(UISettings)
-    bpy.utils.register_class(TransferShapeKeysOperatorUI)
-    bpy.utils.register_class(ShapeKeyItem)
-    load_custom_properties()
-    
-    bpy.utils.register_class(CopyKeyNamesOperator)
-    bpy.utils.register_class(InsertKeyNamesOperator)
-    bpy.utils.register_class(TransferShapeKeyOperator)
-    bpy.utils.register_class(TransferExcludedShapeKeyOperator)
-    bpy.utils.register_class(RemoveShapeKeyOperator)
-    bpy.utils.register_class(CUSTOM_OT_actions)
-    bpy.utils.register_class(CUSTOM_OT_clearList)
-    bpy.utils.register_class(CUSTOM_OT_removeDuplicates)
-    bpy.utils.register_class(CUSTOM_UL_items)
+    from bpy.utils import register_class
+    for cls in classes:
+        register_class(cls)
 
-    
+    bpy.types.Scene.shapekeytransfer_list_index = IntProperty()
+    bpy.types.Scene.shapekeytransfer = PointerProperty(type=SKT_PG_settings)
+    bpy.types.Scene.customshapekeylist = CollectionProperty(type=SKT_PG_shapeKeyListItem)
 
-    bpy.utils.register_class(VIEW3D_PT_tools_ShapeKeyTransfer)
-    
-
-# unregister
-# ----------------------------------------------------------
 
 def unregister():    
-    bpy.utils.unregister_class(UISettings)
-    bpy.utils.unregister_class(TransferShapeKeysOperatorUI)
-    bpy.utils.unregister_class(ShapeKeyItem)
-    
-    bpy.utils.unregister_class(CopyKeyNamesOperator)
-    bpy.utils.unregister_class(InsertKeyNamesOperator)
-    bpy.utils.unregister_class(TransferShapeKeyOperator)
-    bpy.utils.unregister_class(TransferExcludedShapeKeyOperator)
-    bpy.utils.unregister_class(RemoveShapeKeyOperator)
-    bpy.utils.unregister_class(CUSTOM_OT_actions)
-    bpy.utils.unregister_class(CUSTOM_OT_clearList)
-    bpy.utils.unregister_class(CUSTOM_OT_removeDuplicates)
-    bpy.utils.unregister_class(CUSTOM_UL_items)
-    bpy.utils.unregister_class(VIEW3D_PT_tools_ShapeKeyTransfer)
-    del bpy.types.Scene.shapekeytransferSettings
+    from bpy.utils import unregister_class
+    for cls in reversed(classes):
+        unregister_class(cls)
+
+    del bpy.types.Scene.shapekeytransfer
     del bpy.types.Scene.customshapekeylist
-    del bpy.types.Scene.shapekeytransferOperatorSettings
+    del bpy.types.Scene.shapekeytransfer_list_index

--- a/shapekeytransfer.py
+++ b/shapekeytransfer.py
@@ -23,16 +23,11 @@ import bpy
 import bmesh
 from mathutils import Vector
 from . import bl_info
-from .uisettings import TransferShapeKeysOperatorUI
+from .uisettings import SKT_PG_settings
 
-from bpy.props import (StringProperty,
-                       BoolProperty,
-                       IntProperty,
-                       FloatProperty,
-                       FloatVectorProperty,
-                       EnumProperty,
-                       PointerProperty,
-                       )
+from bpy.types import (Operator, 
+                       UIList, 
+                       Panel)
 
 __reload_order_index__ = 1
 
@@ -249,12 +244,13 @@ class ShapeKeyTransfer:
 
 SKT = ShapeKeyTransfer()
 
+
 # Helper function to check if a valid selection is made
 # ----------------------------------------------------------
 
-def can_transfer_keys():
+def can_transfer_keys(context):
     """Checks if selected source and destination meshes are valid"""
-    skt = bpy.context.scene.shapekeytransferSettings
+    skt = context.scene.shapekeytransfer
     if(skt.src_mesh and skt.dest_mesh):
         if(skt.src_mesh == skt.dest_mesh):
             return False
@@ -263,24 +259,25 @@ def can_transfer_keys():
     else:
         return False
 
+
 # Copy all Shape Key names to clipboard Button (Operator)
 # ----------------------------------------------------------
 
-class CopyKeyNamesOperator(bpy.types.Operator):
+class SKT_OT_copyKeyNames(Operator):
     """Copy all Shape Key names to clipboard"""
-    bl_idname = "fblah.copy_key_names"
+    bl_idname = "skt.copy_key_names"
     bl_label = "Copy Shape Key Names"
     bl_description = "Copy Shape Key Names from Source Mesh to clipboard"
     bl_options = {'INTERNAL'}
 
     @classmethod
     def poll(cls, context):
-        skt = bpy.context.scene.shapekeytransferSettings
+        skt = context.scene.shapekeytransfer
         return (skt.src_mesh is not None)
 
     def execute(self, context):
         global SKT
-        skt = bpy.context.scene.shapekeytransferSettings        
+        skt = context.scene.shapekeytransfer        
         if(skt.src_mesh):
             if(SKT.get_shape_keys_mesh(skt.src_mesh)):
                 self.report({'INFO'}, SKT.message)                
@@ -291,39 +288,42 @@ class CopyKeyNamesOperator(bpy.types.Operator):
                     if(key == "Basis"):
                         continue
                     temp_str += key + "\n"
-                bpy.context.window_manager.clipboard = temp_str
+                context.window_manager.clipboard = temp_str
                 self.report({'INFO'}, "Copied to clipboard")
         else:
             self.report({'INFO'}, "Invalid Source Mesh")
         return{'FINISHED'}
 
+
 # Copy all Shape Key names from clipboard Button (Operator)
 # ----------------------------------------------------------
 
-class InsertKeyNamesOperator(bpy.types.Operator):
+class SKT_OT_insertKeyNames(Operator):
     """Copy all Shape Key names from clipboard"""
-    bl_idname = "fblah.insert_key_names"
+    bl_idname = "skt.insert_key_names"
     bl_label = "Insert Shape Key Names"
     bl_description = "Insert Shape Key Names from clipboard. Each name in one line"
     bl_options = {'INTERNAL'}   
 
     def execute(self, context):
         scn = context.scene
-        for key in bpy.context.window_manager.clipboard.split("\n"):
+        for key in context.window_manager.clipboard.split("\n"):
             if(len(key)):
                 item = scn.customshapekeylist.add()
                 item.name = key
                 item.obj_type = "STRING"
                 item.obj_id = len(scn.customshapekeylist)
-                scn.customshapekeylist_index = len(scn.customshapekeylist)-1
+                scn.shapekeytransfer_list_index = len(scn.customshapekeylist)-1
         self.report({'INFO'}, "Added shape key names from clipboard")
         return{'FINISHED'}
+
+
 # Transfer Shape Keys Button (Operator)
 # ----------------------------------------------------------
 
-class TransferShapeKeyOperator(bpy.types.Operator):
+class SKT_OT_transferShapeKeys(Operator):
     """Transfers shape keys in selected meshes"""
-    bl_idname = "fblah.transfer_shape_keys"
+    bl_idname = "skt.transfer_shape_keys"
     bl_label = "Transfer Shape Keys"
     bl_description = 'The two meshes must be overlapping or really close'
     bl_context = 'objectmode'
@@ -331,16 +331,15 @@ class TransferShapeKeyOperator(bpy.types.Operator):
     
     @classmethod
     def poll(cls, context):
-        return can_transfer_keys()
+        return can_transfer_keys(context)
 
     def execute(self, context):
         global SKT
-        skt = bpy.context.scene.shapekeytransferSettings
-        sktop = bpy.context.scene.shapekeytransferOperatorSettings 
-        SKT.increment_radius = sktop.increment_radius
-        SKT.use_one_vertex   = sktop.use_one_vertex
-        SKT.skip_vertices_with_no_pair = sktop.skip_unpaired_vertices
-        SKT.number_of_increments = sktop.number_of_increments
+        skt = context.scene.shapekeytransfer
+        SKT.increment_radius = skt.increment_radius
+        SKT.use_one_vertex   = skt.use_one_vertex
+        SKT.skip_vertices_with_no_pair = skt.skip_unpaired_vertices
+        SKT.number_of_increments = skt.number_of_increments
 
         SKT.update_shape_keys_list(context.scene.customshapekeylist)
         result = SKT.transfer_shape_keys(skt.src_mesh, skt.dest_mesh)
@@ -352,39 +351,37 @@ class TransferShapeKeyOperator(bpy.types.Operator):
     
     def draw(self, context):
         layout = self.layout
-        sktop = bpy.context.scene.shapekeytransferOperatorSettings 
+        skt = context.scene.shapekeytransfer
         col = layout.column()
         col.label(text="Vertex influence:")       
-        col.prop(sktop, "increment_radius")
-        col.prop(sktop, "use_one_vertex")
-        col.prop(sktop, "skip_unpaired_vertices")
-        col.prop(sktop, "number_of_increments")
+        col.prop(skt, "increment_radius")
+        col.prop(skt, "use_one_vertex")
+        col.prop(skt, "skip_unpaired_vertices")
+        col.prop(skt, "number_of_increments")
+
 
 # Transfer Shape Keys in excluded shape keys list Button  (Operator)
 # ----------------------------------------------------------
 
-class TransferExcludedShapeKeyOperator(bpy.types.Operator):
+class SKT_OT_transferExcludedShapeKeys(Operator):
     """Transfers shape keys from excluded shape keys list in selected meshes"""
-    bl_idname = "fblah.transfer_excluded_shape_keys"
+    bl_idname = "skt.transfer_excluded_shape_keys"
     bl_label = "Transfer Excluded Shape Keys Only"
     bl_description = 'The two meshes must be overlapping or really close'
     bl_context = 'objectmode'
     bl_options = {'REGISTER', 'INTERNAL','UNDO'}
 
-    
-
     @classmethod
     def poll(cls, context):
-        return can_transfer_keys()
+        return can_transfer_keys(context)
 
     def execute(self, context):
         global SKT
-        skt = bpy.context.scene.shapekeytransferSettings        
-        sktop = bpy.context.scene.shapekeytransferOperatorSettings 
-        SKT.increment_radius = sktop.increment_radius
-        SKT.use_one_vertex   = sktop.use_one_vertex
-        SKT.skip_vertices_with_no_pair = sktop.skip_unpaired_vertices
-        SKT.number_of_increments = sktop.number_of_increments
+        skt = context.scene.shapekeytransfer
+        SKT.increment_radius = skt.increment_radius
+        SKT.use_one_vertex   = skt.use_one_vertex
+        SKT.skip_vertices_with_no_pair = skt.skip_unpaired_vertices
+        SKT.number_of_increments = skt.number_of_increments
         
         SKT.update_shape_keys_list(context.scene.customshapekeylist)
         result = SKT.transfer_shape_keys(skt.src_mesh, skt.dest_mesh, True)
@@ -395,22 +392,22 @@ class TransferExcludedShapeKeyOperator(bpy.types.Operator):
         return {'FINISHED'}
     
     def draw(self, context):
-        sktop = bpy.context.scene.shapekeytransferOperatorSettings
+        skt = context.scene.shapekeytransfer
         layout = self.layout
         col = layout.column()
         col.label(text="Vertex influence:")       
-        col.prop(sktop, "increment_radius")
-        col.prop(sktop, "use_one_vertex")
-        col.prop(sktop, "skip_unpaired_vertices")
-        col.prop(sktop, "number_of_increments")
+        col.prop(skt, "increment_radius")
+        col.prop(skt, "use_one_vertex")
+        col.prop(skt, "skip_unpaired_vertices")
+        col.prop(skt, "number_of_increments")
         
 
 # Remove all Shape Keys in source mesh Button (Operator)
 # ----------------------------------------------------------
 
-class RemoveShapeKeyOperator(bpy.types.Operator):
+class SKT_OT_removeShapeKeys(Operator):
     """Remove all Shape Keys in source mesh"""
-    bl_idname = "fblah.remove_shape_keys"
+    bl_idname = "skt.remove_shape_keys"
     bl_label = "Remove Shape Keys in src"
     bl_description = 'Remove all Shape Keys in source mesh'
     bl_context = 'objectmode'
@@ -418,12 +415,12 @@ class RemoveShapeKeyOperator(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        skt = bpy.context.scene.shapekeytransferSettings
+        skt = context.scene.shapekeytransfer
         return (skt.src_mesh is not None)
 
     def execute(self, context):
         global SKT
-        skt = bpy.context.scene.shapekeytransferSettings        
+        skt = context.scene.shapekeytransfer        
         if(skt.src_mesh):
             ob = SKT.get_parent(skt.src_mesh)
             if(ob.data.shape_keys):
@@ -443,7 +440,7 @@ class RemoveShapeKeyOperator(bpy.types.Operator):
 # Manage customshapekeylist items (Operator)
 # ----------------------------------------------------------
 
-class CUSTOM_OT_actions(bpy.types.Operator):
+class SKT_OT_actions(Operator):
     """Move items up and down, add and remove"""
     bl_idname = "customshapekeylist.list_action"
     bl_label = "List Actions"
@@ -460,7 +457,7 @@ class CUSTOM_OT_actions(bpy.types.Operator):
 
     def invoke(self, context, event):
         scn = context.scene
-        idx = scn.customshapekeylist_index
+        idx = scn.shapekeytransfer_list_index
 
         try:
             item = scn.customshapekeylist[idx]
@@ -470,30 +467,30 @@ class CUSTOM_OT_actions(bpy.types.Operator):
             if self.action == 'DOWN' and idx < len(scn.customshapekeylist) - 1:
                 item_next = scn.customshapekeylist[idx+1].name
                 scn.customshapekeylist.move(idx, idx+1)
-                scn.customshapekeylist_index += 1
-                info = 'Item "%s" moved to position %d' % (item.name, scn.customshapekeylist_index + 1)
+                scn.shapekeytransfer_list_index += 1
+                info = 'Item "%s" moved to position %d' % (item.name, scn.shapekeytransfer_list_index + 1)
                 self.report({'INFO'}, info)
 
             elif self.action == 'UP' and idx >= 1:
                 item_prev = scn.customshapekeylist[idx-1].name
                 scn.customshapekeylist.move(idx, idx-1)
-                scn.customshapekeylist_index -= 1
-                info = 'Item "%s" moved to position %d' % (item.name, scn.customshapekeylist_index + 1)
+                scn.shapekeytransfer_list_index -= 1
+                info = 'Item "%s" moved to position %d' % (item.name, scn.shapekeytransfer_list_index + 1)
                 self.report({'INFO'}, info)
 
             elif self.action == 'REMOVE':
                 info = 'Item "%s" removed from list' % (scn.customshapekeylist[idx].name)
-                scn.customshapekeylist_index -= 1
+                scn.shapekeytransfer_list_index -= 1
                 scn.customshapekeylist.remove(idx)
                 self.report({'INFO'}, info)
             
         if self.action == 'ADD':                               
-            scn = bpy.context.scene
+            scn = context.scene
             item = scn.customshapekeylist.add()
             item.name = "key"
             item.obj_type = "STRING"
             item.obj_id = len(scn.customshapekeylist)
-            scn.customshapekeylist_index = len(scn.customshapekeylist)-1             
+            scn.shapekeytransfer_list_index = len(scn.customshapekeylist)-1             
             info = '"%s" added to list' % (item.name)
             self.report({'INFO'}, info)
         
@@ -503,7 +500,7 @@ class CUSTOM_OT_actions(bpy.types.Operator):
                 item.name = key
                 item.obj_type = "STRING"
                 item.obj_id = len(scn.customshapekeylist)
-                scn.customshapekeylist_index = len(scn.customshapekeylist)-1
+                scn.shapekeytransfer_list_index = len(scn.customshapekeylist)-1
                 info = '"%s" added to list' % (item.name)
                 self.report({'INFO'}, info)
         
@@ -512,7 +509,7 @@ class CUSTOM_OT_actions(bpy.types.Operator):
 # Clear customshapekeylist items (Operator)
 # ----------------------------------------------------------
 
-class CUSTOM_OT_clearList(bpy.types.Operator):
+class SKT_OT_clearList(Operator):
     """Clear all items of the list"""
     bl_idname = "customshapekeylist.clear_list"
     bl_label = "Clear List"
@@ -537,7 +534,7 @@ class CUSTOM_OT_clearList(bpy.types.Operator):
 # Remove duplicates among customshapekeylist items (Operator)
 # ----------------------------------------------------------
 
-class CUSTOM_OT_removeDuplicates(bpy.types.Operator):
+class SKT_OT_removeDuplicates(Operator):
     """Remove all duplicates"""
     bl_idname = "customshapekeylist.remove_duplicates"
     bl_label = "Remove Duplicates"
@@ -567,7 +564,7 @@ class CUSTOM_OT_removeDuplicates(bpy.types.Operator):
             scn.customshapekeylist.remove(i)
             removed_items.append(i)
         if removed_items:
-            scn.customshapekeylist_index = len(scn.customshapekeylist)-1
+            scn.shapekeytransfer_list_index = len(scn.customshapekeylist)-1
             info = ', '.join(map(str, removed_items))
             self.report({'INFO'}, "Removed indices: %s" % (info))
         else:
@@ -580,7 +577,7 @@ class CUSTOM_OT_removeDuplicates(bpy.types.Operator):
 # customshapekeylist items (UIList)
 # ----------------------------------------------------------
 
-class CUSTOM_UL_items(bpy.types.UIList):
+class SKT_UL_items(UIList):
     """Item in customshapekeylist"""
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
         #split = layout.split(0.3)
@@ -595,10 +592,9 @@ class CUSTOM_UL_items(bpy.types.UIList):
 # Main addon panel (Panel)
 # ----------------------------------------------------------
 
-class VIEW3D_PT_tools_ShapeKeyTransfer(bpy.types.Panel):
+class SKT_PT_view3D(Panel):
     """Shape Key Tools Panel layout"""
-    bl_label = "Shape Key Tools"
-    bl_idname = "OBJECT_SHAPE_KEY_TRANSFER_PANEL"
+    bl_label = "Shape Key Transfer"
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
     bl_context = 'objectmode'
@@ -610,43 +606,43 @@ class VIEW3D_PT_tools_ShapeKeyTransfer(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        scn = bpy.context.scene
-        skt = context.scene.shapekeytransferSettings
+        scn = context.scene
+        skt = scn.shapekeytransfer
 
         icon_expand = "DISCLOSURE_TRI_RIGHT"
         icon_collapse = "DISCLOSURE_TRI_DOWN"
         
-        if(not can_transfer_keys()):
+        if not can_transfer_keys(context):
             layout.label(text="Select required meshes", icon = 'INFO')
         
         layout.prop(skt, "src_mesh", text="Source Mesh") 
         layout.prop(skt, "dest_mesh", text="Destination Mesh")
-        layout.operator('fblah.transfer_shape_keys', icon='ARROW_LEFTRIGHT')
-        layout.operator('fblah.transfer_excluded_shape_keys', icon='KEYINGSET') #ALIGN ICON no longer available
+        layout.operator(SKT_OT_transferShapeKeys.bl_idname, icon='ARROW_LEFTRIGHT')
+        layout.operator(SKT_OT_transferExcludedShapeKeys.bl_idname, icon='KEYINGSET')
         layout.separator()
-        layout.operator('fblah.remove_shape_keys', icon='CANCEL')
+        layout.operator(SKT_OT_removeShapeKeys.bl_idname, icon='CANCEL')
 
         layout.separator()
         layout.label(text="Excluded Shape Keys")
-        rows = 2
+        rows = 5
         row = layout.row()
-        row.template_list("CUSTOM_UL_items", "", scn, "customshapekeylist", scn, "customshapekeylist_index", rows=rows)
+        row.template_list("SKT_UL_items", "", scn, "customshapekeylist", scn, "shapekeytransfer_list_index", rows=rows)
 
         col = row.column(align=True)
-        col.operator("customshapekeylist.list_action", icon='PLUS', text="").action = 'ADD'
-        col.operator("customshapekeylist.list_action", icon='REMOVE', text="").action = 'REMOVE'
+        col.operator(SKT_OT_actions.bl_idname, icon='PLUS', text="").action = 'ADD'
+        col.operator(SKT_OT_actions.bl_idname, icon='REMOVE', text="").action = 'REMOVE'
         col.separator()
-        col.operator("customshapekeylist.list_action", icon='TRIA_UP', text="").action = 'UP'
-        col.operator("customshapekeylist.list_action", icon='TRIA_DOWN', text="").action = 'DOWN'
-        col.operator("customshapekeylist.list_action", icon='RECOVER_LAST', text="").action = 'DEFAULT'
+        col.operator(SKT_OT_actions.bl_idname, icon='TRIA_UP', text="").action = 'UP'
+        col.operator(SKT_OT_actions.bl_idname, icon='TRIA_DOWN', text="").action = 'DOWN'
+        col.operator(SKT_OT_actions.bl_idname, icon='RECOVER_LAST', text="").action = 'DEFAULT'
 
         row = layout.row()
         col = row.column(align=True)        
         row = col.row(align=True)
-        row.operator("customshapekeylist.clear_list", icon="X")
-        row.operator("customshapekeylist.remove_duplicates", icon="FORCE_VORTEX")
+        row.operator(SKT_OT_clearList.bl_idname, icon="X")
+        row.operator(SKT_OT_removeDuplicates.bl_idname, icon="FORCE_VORTEX")
         row = layout.row()
         col = row.column(align=True)        
         row = col.row(align=True)
-        row.operator("fblah.copy_key_names", icon="COPYDOWN")
-        row.operator("fblah.insert_key_names", icon="IMPORT")
+        row.operator(SKT_OT_copyKeyNames.bl_idname, icon="COPYDOWN")
+        row.operator(SKT_OT_insertKeyNames.bl_idname, icon="IMPORT")

--- a/shapekeytransfer.py
+++ b/shapekeytransfer.py
@@ -22,14 +22,12 @@
 import bpy
 import bmesh
 from mathutils import Vector
-from . import bl_info
-from .uisettings import SKT_PG_settings
 
 from bpy.types import (Operator, 
                        UIList, 
                        Panel)
 
-__reload_order_index__ = 1
+# __reload_order_index__ = 1
 
 # Class which handles shape key transfers
 # ----------------------------------------------------------
@@ -260,14 +258,14 @@ def can_transfer_keys(context):
         return False
 
 
-# Copy all Shape Key names to clipboard Button (Operator)
+# Copy all Shape Key names to Clipboard Button
 # ----------------------------------------------------------
 
 class SKT_OT_copyKeyNames(Operator):
-    """Copy all Shape Key names to clipboard"""
+    """Copy all Shape Key names to Clipboard"""
     bl_idname = "skt.copy_key_names"
     bl_label = "Copy Shape Key Names"
-    bl_description = "Copy Shape Key Names from Source Mesh to clipboard"
+    bl_description = "Copy Shape Key Names from Source Mesh to Clipboard"
     bl_options = {'INTERNAL'}
 
     @classmethod
@@ -289,20 +287,20 @@ class SKT_OT_copyKeyNames(Operator):
                         continue
                     temp_str += key + "\n"
                 context.window_manager.clipboard = temp_str
-                self.report({'INFO'}, "Copied to clipboard")
+                self.report({'INFO'}, "Copied to Clipboard")
         else:
             self.report({'INFO'}, "Invalid Source Mesh")
         return{'FINISHED'}
 
 
-# Copy all Shape Key names from clipboard Button (Operator)
+# Copy all Shape Key names from clipboard Button
 # ----------------------------------------------------------
 
 class SKT_OT_insertKeyNames(Operator):
-    """Copy all Shape Key names from clipboard"""
+    """Copy all Shape Key Names from the Clipboard"""
     bl_idname = "skt.insert_key_names"
     bl_label = "Insert Shape Key Names"
-    bl_description = "Insert Shape Key Names from clipboard. Each name in one line"
+    bl_description = "Insert Shape Key Names from Clipboard (Each name per Row)"
     bl_options = {'INTERNAL'}   
 
     def execute(self, context):
@@ -314,7 +312,7 @@ class SKT_OT_insertKeyNames(Operator):
                 item.obj_type = "STRING"
                 item.obj_id = len(scn.customshapekeylist)
                 scn.shapekeytransfer_list_index = len(scn.customshapekeylist)-1
-        self.report({'INFO'}, "Added shape key names from clipboard")
+        self.report({'INFO'}, "Added shape key names from Clipboard")
         return{'FINISHED'}
 
 
@@ -322,10 +320,10 @@ class SKT_OT_insertKeyNames(Operator):
 # ----------------------------------------------------------
 
 class SKT_OT_transferShapeKeys(Operator):
-    """Transfers shape keys in selected meshes"""
+    """Transfers Shape Keys to Selected Mesh"""
     bl_idname = "skt.transfer_shape_keys"
     bl_label = "Transfer Shape Keys"
-    bl_description = 'The two meshes must be overlapping or really close'
+    bl_description = "The two meshes should overlap each other or positioned pretty close"
     bl_context = 'objectmode'
     bl_options = {'REGISTER', 'INTERNAL','UNDO'}
     
@@ -364,10 +362,10 @@ class SKT_OT_transferShapeKeys(Operator):
 # ----------------------------------------------------------
 
 class SKT_OT_transferExcludedShapeKeys(Operator):
-    """Transfers shape keys from excluded shape keys list in selected meshes"""
+    """Transfers Shape Keys from excluded Shape key list"""
     bl_idname = "skt.transfer_excluded_shape_keys"
     bl_label = "Transfer Excluded Shape Keys Only"
-    bl_description = 'The two meshes must be overlapping or really close'
+    bl_description = "The two meshes should overlap each other or positioned pretty close"
     bl_context = 'objectmode'
     bl_options = {'REGISTER', 'INTERNAL','UNDO'}
 
@@ -406,10 +404,10 @@ class SKT_OT_transferExcludedShapeKeys(Operator):
 # ----------------------------------------------------------
 
 class SKT_OT_removeShapeKeys(Operator):
-    """Remove all Shape Keys in source mesh"""
-    bl_idname = "skt.remove_shape_keys"
-    bl_label = "Remove Shape Keys in src"
-    bl_description = 'Remove all Shape Keys in source mesh'
+    """Remove all Shape Keys of Source Mesh"""
+    bl_idname = "skt.remove_src_shape_keys"
+    bl_label = "Remove Shape Keys of Source"
+    bl_description = "Remove all Shape Keys of Source Mesh"
     bl_context = 'objectmode'
     bl_options = {'REGISTER', 'INTERNAL','UNDO'}
 
@@ -535,10 +533,10 @@ class SKT_OT_clearList(Operator):
 # ----------------------------------------------------------
 
 class SKT_OT_removeDuplicates(Operator):
-    """Remove all duplicates"""
+    """Remove all duplicates in the list"""
     bl_idname = "customshapekeylist.remove_duplicates"
-    bl_label = "Remove Duplicates"
-    bl_description = "Remove all duplicates"
+    bl_label = "Remove Doubles"
+    bl_description = "Remove all Duplicates in the List"
     bl_options = {'INTERNAL'}
 
     def find_duplicates(self, context):
@@ -606,17 +604,21 @@ class SKT_PT_view3D(Panel):
 
     def draw(self, context):
         layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False  # No animation.
+
         scn = context.scene
         skt = scn.shapekeytransfer
-
-        icon_expand = "DISCLOSURE_TRI_RIGHT"
-        icon_collapse = "DISCLOSURE_TRI_DOWN"
         
+        '''
         if not can_transfer_keys(context):
-            layout.label(text="Select required meshes", icon = 'INFO')
-        
+            layout.label(text="Set required meshes", icon='INFO')
+        '''
+
         layout.prop(skt, "src_mesh", text="Source Mesh") 
         layout.prop(skt, "dest_mesh", text="Destination Mesh")
+
+        layout.separator()
         layout.operator(SKT_OT_transferShapeKeys.bl_idname, icon='ARROW_LEFTRIGHT')
         layout.operator(SKT_OT_transferExcludedShapeKeys.bl_idname, icon='KEYINGSET')
         layout.separator()
@@ -636,13 +638,12 @@ class SKT_PT_view3D(Panel):
         col.operator(SKT_OT_actions.bl_idname, icon='TRIA_DOWN', text="").action = 'DOWN'
         col.operator(SKT_OT_actions.bl_idname, icon='RECOVER_LAST', text="").action = 'DEFAULT'
 
-        row = layout.row()
-        col = row.column(align=True)        
+        col = layout.column(align=True)        
         row = col.row(align=True)
-        row.operator(SKT_OT_clearList.bl_idname, icon="X")
         row.operator(SKT_OT_removeDuplicates.bl_idname, icon="FORCE_VORTEX")
-        row = layout.row()
-        col = row.column(align=True)        
-        row = col.row(align=True)
-        row.operator(SKT_OT_copyKeyNames.bl_idname, icon="COPYDOWN")
-        row.operator(SKT_OT_insertKeyNames.bl_idname, icon="IMPORT")
+        row.operator(SKT_OT_clearList.bl_idname, icon="X")
+        col = col.column(align=True)
+        col.operator(SKT_OT_copyKeyNames.bl_idname, icon="COPYDOWN")
+        col.operator(SKT_OT_insertKeyNames.bl_idname, icon="IMPORT")
+
+        layout.separator()

--- a/uisettings.py
+++ b/uisettings.py
@@ -25,21 +25,18 @@ from bpy.props import (StringProperty,
                        BoolProperty,
                        IntProperty,
                        FloatProperty,
-                       FloatVectorProperty,
-                       EnumProperty,
-                       PointerProperty,
-                       )
-from bpy.types import (Panel,
-                       Operator,
-                       PropertyGroup,
-                       )
+                       PointerProperty)
 
-# Properties of the main part of the panel
+from bpy.types import PropertyGroup
+
+
+# Scene Properties
 # ----------------------------------------------------------
 
-class UISettings(PropertyGroup):
-    """Mesh Selection Boxes"""
-    src_mesh : PointerProperty(
+class SKT_PG_settings(PropertyGroup):
+    """SKT scene properties"""
+
+    src_mesh: PointerProperty(
         type=bpy.types.Mesh, 
         name="Source Mesh", 
         description="Select a source mesh", 
@@ -47,7 +44,7 @@ class UISettings(PropertyGroup):
         update=None
         )
     
-    dest_mesh : PointerProperty(
+    dest_mesh: PointerProperty(
         type=bpy.types.Mesh, 
         name="Destination Mesh", 
         description="Select a destination mesh", 
@@ -55,30 +52,25 @@ class UISettings(PropertyGroup):
         update=None
         )
 
-# Properties of the operator
-# ----------------------------------------------------------
-
-class TransferShapeKeysOperatorUI(PropertyGroup):
-    """Transfer shape key operator options and properties"""
-    specify_end_vertex : BoolProperty(
+    specify_end_vertex: BoolProperty(
         name="Specify End Vertex",
         description="Execute till last vertex specified.",
         default = False
         )
 
-    use_one_vertex : BoolProperty(
+    use_one_vertex: BoolProperty(
         name="Use Closest Vertex",
         description="Use the position of the closet vertex only or several vertices within the range.",
         default = True
         )
     
-    skip_unpaired_vertices : BoolProperty(
+    skip_unpaired_vertices: BoolProperty(
         name="Skip unpaired vertices",
         description="Use this to skip vertices which cant find naerby vertices in source mesh to copy position from.",
         default = True
         )
 
-    increment_radius : FloatProperty(
+    increment_radius: FloatProperty(
         name = "Increment Radius",
         description = "Radius to increment selection sphere.",
         default = 0.05,
@@ -87,7 +79,7 @@ class TransferShapeKeysOperatorUI(PropertyGroup):
         min = 0.00000001
         )
     
-    number_of_increments : IntProperty(
+    number_of_increments: IntProperty(
         name = "Number of increments",
         description = "Number of times to increment selection radius before giving up.",
         default = 2,
@@ -99,8 +91,8 @@ class TransferShapeKeysOperatorUI(PropertyGroup):
 # Property of 1 item in the excluded shape key list
 # ----------------------------------------------------------
 
-class ShapeKeyItem(PropertyGroup):
+class SKT_PG_shapeKeyListItem(PropertyGroup):
     """List box properties"""
-    #name = StringProperty() -> Instantiated by default    
-    obj_type = StringProperty()
-    obj_id = IntProperty()
+    #name : StringProperty() -> Instantiated by default    
+    obj_type: StringProperty()
+    obj_id: IntProperty()


### PR DESCRIPTION
Hi @fblah,

this PR fixes all warnings for Blender 2.93+. It is also a general cleanup of context references, naming of the classes, properties, registration, UI and all namespaces according to the current conventions, which should hopefully make it way easier to maintain as well as to contribute. What do you think?

Cheers,
Christian

BTW: Fun to see [my code from here](https://blender.stackexchange.com/questions/30444/create-an-interface-which-is-similar-to-the-material-list-box) in this.